### PR TITLE
Fixes problems with requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ click-repl==0.1.6
 dill==0.3.3
 html2text==2020.1.16
 idna==2.10
+jsonlines==2.0.0
 kombu==5.0.2
 multiprocess==0.70.11.1
 numexpr==2.7.1


### PR DESCRIPTION
Fixes a typo in `requirements.txt` that caused an error when installing dependencies.
```
loom$ pip install -r requirements.txt
ERROR: Invalid requirement: 'pandas==1.3,3' (from line 18 of requirements.txt)
```

And adds `jsonlines` as a dependency.
```
loom$ python main.py
ModuleNotFoundError: No module named 'jsonlines'
```