### PR TITLE
Update openai api

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ idna==2.10
 jsonlines==2.0.0
 kombu==5.0.2
 multiprocess==0.70.11.1
-openai>=0.27.2
+openai>=1.1.1
 pandas==1.3.3
 pathos==0.2.7
 pillow>=9.4.0

--- a/util/gpt_util.py
+++ b/util/gpt_util.py
@@ -27,7 +27,7 @@ def total_logprob(response):
 
 
 def tokenize_ada(prompt):
-    response = openai.Completion.create(
+    response = openai.completions.create(
         engine='ada',
         prompt=prompt,
         max_tokens=0,
@@ -41,7 +41,7 @@ def tokenize_ada(prompt):
 
 
 def prompt_probs(prompt, engine='ada'):
-    response = openai.Completion.create(
+    response = openai.completions.create(
         engine=engine,
         prompt=prompt,
         max_tokens=0,
@@ -57,7 +57,7 @@ def prompt_probs(prompt, engine='ada'):
 # evaluates logL(prompt+target | prompt)
 def conditional_logprob(prompt, target, engine='ada'):
     combined = prompt + target
-    response = openai.Completion.create(
+    response = openai.completions.create(
         engine=engine,
         prompt=combined,
         max_tokens=0,
@@ -135,7 +135,7 @@ def substring_probs(preprompt, content, target, engine='ada', quiet=0):
 # returns a list of substrings of content
 # logL(substring+target | substring) for each substring
 def token_conditional_logprob(content, target, engine='ada'):
-    response = openai.Completion.create(
+    response = openai.completions.create(
         engine=engine,
         prompt=content,
         max_tokens=0,

--- a/util/multiverse_util.py
+++ b/util/multiverse_util.py
@@ -14,12 +14,13 @@ def generate(prompt, engine, goose=False):
         openai.api_key = os.environ.get("OPENAI_API_KEY", None)
     #print('calling engine', engine, 'at endpoint', openai.api_base)
     #print('prompt:', prompt)
-    response = openai.Completion.create(prompt=prompt,
+    response = openai.completions.create(prompt=prompt,
                                         max_tokens=1,
                                         n=1,
                                         temperature=0,
                                         logprobs=100,
                                         model=engine)
+    response = response.dict()
     return response
 
 # TODO multiple "ground truth" trajectories


### PR DESCRIPTION
Sharing some local changes I made to continue using loom with openai models now that the chat completions endpoint does not support logprobs [1]. Hardcodes using a non-chat model (davinci) if needed and updates the API syntax to the latest version of the openai client library.

Is anyone else still using openai models for loom? I notice there's a feature branch (metaprocesses) with new code using openai.

[1] https://community.openai.com/t/logprobs-are-missing-from-the-chat-endpoints/289514