### PR TITLE
Fix Tk 9 crash on startup and generation-thread callbacks

### DIFF
--- a/components/dialogs.py
+++ b/components/dialogs.py
@@ -383,7 +383,7 @@ class AddTagDialog(Dialog):
         self.show_only_checkbox = create_checkbutton(master, "Show only", 'show_only', self.vars)
         self.configure_checkbuttons()
         for var in self.vars.values():
-            var.trace('w', self.configure_checkbuttons)
+            var.trace_add('write', self.configure_checkbuttons)
         keybinding_options = special_keybindings.keys()
         self.vars['toggle_key'].set('None')
         create_side_label(master, "Toggle key")
@@ -491,7 +491,7 @@ class TagsDialog(Dialog):
 
         # trace all vars to configure checkbuttons
         for var in self.vars[tag].values():
-            var.trace('w', lambda *_, _tag=tag: self.configure_checkbuttons(_tag))
+            var.trace_add('write', lambda *_, _tag=tag: self.configure_checkbuttons(_tag))
 
         self.widgets[tag]['toggle_key_dropdown'] = tk.OptionMenu(self.master, self.vars[tag]['toggle_key'], *keybinding_options)
         self.widgets[tag]['toggle_key_dropdown'].grid(row=self.master.grid_size()[1]-1, column=4, pady=3)

--- a/components/modules.py
+++ b/components/modules.py
@@ -104,7 +104,7 @@ class Paint(Module):
                                             variable=self.past_recursive_veil_opacity)
         self.past_opacity_slider.grid(row=0, column=7)
         self.past_opacity_slider.set(0.2)
-        self.past_recursive_veil_opacity.trace('w', self.update_past_veil_opacity)
+        self.past_recursive_veil_opacity.trace_add('write', self.update_past_veil_opacity)
 
         self.c = tk.Canvas(self.root, bg='white', width=600, height=600)
         self.c.grid(row=1, columnspan=6)
@@ -1267,7 +1267,7 @@ class Edit(Module):
         template_presets = ['children_list']
         self.templates_dropdown = tk.OptionMenu(self.templates_frame, self.template_preset, None, *template_presets)
         self.templates_dropdown.pack(side='left')
-        self.template_preset.trace("w", self.template_preset_changed)
+        self.template_preset.trace_add('write', self.template_preset_changed)
 
         self.textboxes_frame = ttk.Frame(self.frame)
         self.textboxes_frame.pack(side='top', fill='both', expand=True)
@@ -1735,7 +1735,7 @@ class FrameEditor(Module):
         self.preset = tk.StringVar()
         self.get_presets()
         self.set_presets()
-        self.preset.trace('w', self.apply_preset)
+        self.preset.trace_add('write', self.apply_preset)
 
         self.write_to_user_frame_button = tk.Button(self.frame, text="Copy to user frame", command=self.write_to_user_frame)
         self.write_to_user_frame_button.pack(side='top', pady=10)

--- a/components/templates.py
+++ b/components/templates.py
@@ -906,7 +906,7 @@ class Settings:
     def init_vars(self):
         for key in self.vars.keys():
             self.vars[key] = self.vars[key](value=self.orig_params[key])
-            self.vars[key].trace("w", lambda a, b, c, key=key: self.set_var(key=key))
+            self.vars[key].trace_add('write', lambda a, b, c, key=key: self.set_var(key=key))
     
     def set_var(self, key):
         if self.realtime_update:
@@ -1183,7 +1183,7 @@ def full_generation_settings_init(self):
         }
     for key in additional_vars.keys():
         self.vars[key] = additional_vars[key](value=self.orig_params[key])
-        self.vars[key].trace("w", lambda a, b, c, key=key: self.set_var(key=key))
+        self.vars[key].trace_add('write', lambda a, b, c, key=key: self.set_var(key=key))
     
     self.textboxes.update({'start': None,
                             'restart': None,})
@@ -1254,7 +1254,7 @@ def generation_settings_templates_body(self, build_pins=False):
     row = self.frame.grid_size()[1]
     self.template_label = create_side_label(self.frame, "template")
     self.template_filename_label = create_side_label(self.frame, self.vars['template'].get(), row=row, col=1)
-    self.vars['template'].trace("w", self.set_template)
+    self.vars['template'].trace_add('write', self.set_template)
     if build_pins:
         self.build_pin_button('template')
 
@@ -1271,7 +1271,7 @@ def generation_settings_templates_body(self, build_pins=False):
             self.presets_dict.update(json.load(f))
 
     # when the preset changes, apply the preset
-    self.vars['preset'].trace('w', self.apply_preset)
+    self.vars['preset'].trace_add('write', self.apply_preset)
 
     self.preset_dropdown = tk.OptionMenu(self.frame, self.vars["preset"], "Select preset...")
     self.preset_dropdown.grid(row=row, column=1)

--- a/model.py
+++ b/model.py
@@ -1,6 +1,8 @@
 import functools
 import os
+import queue
 import threading
+import traceback
 import time
 import math
 import uuid
@@ -269,6 +271,9 @@ DEFAULT_TAGS = {
     }
  }
 
+# how often the main thread picks up work handed to it by generation threads
+MAIN_THREAD_POLL_MS = 50
+
 EMPTY_TREE = {
     "root": {
         "mutable": False,
@@ -289,7 +294,10 @@ class TreeModel:
     def __init__(self, root):
         self.app = root
         self.app.bind("<<TreeUpdated>>", lambda _: self.tree_updated())
-        self.app.bind("<<NewNodes>>", lambda _: self.edit_new_nodes())
+        # Work that generation threads need run on the main thread. Virtual events are
+        # not delivered across threads, so the main thread drains this on a timer.
+        self.main_thread_queue = queue.Queue()
+        self.app.after(MAIN_THREAD_POLL_MS, self.drain_main_thread_queue)
 
         # All variables initialized below
         self.tree_filename = None
@@ -519,6 +527,22 @@ class TreeModel:
     def tree_updated(self, rebuild_dict=True, **kwargs):
         if self.tree_raw_data and rebuild_dict:
             self.rebuild_tree()
+
+    def call_on_main_thread(self, callback):
+        """Generation runs in a worker thread, and Tk may only be touched from the main one."""
+        self.main_thread_queue.put(callback)
+
+    def drain_main_thread_queue(self):
+        while True:
+            try:
+                callback = self.main_thread_queue.get_nowait()
+            except queue.Empty:
+                break
+            try:
+                callback()
+            except Exception:
+                traceback.print_exc()
+        self.app.after(MAIN_THREAD_POLL_MS, self.drain_main_thread_queue)
 
     # def tree_updated_silent(self):
     #     self.rebuild_tree()
@@ -1959,7 +1983,7 @@ class TreeModel:
             print("Generated continuation:\n", result['text'], "\nerror", error)
 
         # DO NOT CALL FROM THREAD: self.tree_updated()
-        self.app.event_generate("<<NewNodes>>", when="tail")
+        self.call_on_main_thread(self.edit_new_nodes)
 
     def default_post_template(self, completion):
         start_text = codecs.decode(self.generation_settings['start'], "unicode-escape")
@@ -1989,7 +2013,9 @@ class TreeModel:
         for node in nodes:
             parent = self.parent(node)
             parent["children"].remove(node)
-        self.tree_updated(delete=[node['id'] for node in nodes])
+        deleted = [node['id'] for node in nodes]
+        # DO NOT CALL FROM THREAD: self.tree_updated()
+        self.call_on_main_thread(lambda: self.tree_updated(delete=deleted))
 
     def default_generate(self, prompt, nodes):
         results, error = gen(prompt, self.generation_settings, self.model_config,

--- a/util/util.py
+++ b/util/util.py
@@ -426,7 +426,7 @@ def retry(func=None, exception=Exception, n_tries=5, delay=0.1,
                 ndelay *= backoff
 
         if on_failure is not None:
-            on_failure(*args, **kwargs)
+            return on_failure(*args, **kwargs)
         else:
             raise exe
 

--- a/view/panes.py
+++ b/view/panes.py
@@ -136,7 +136,7 @@ class ModuleWindow:
         self.module_selection.set('None')
         self.module_menu = tk.OptionMenu(self.menu_frame, self.module_selection, *options)
         self.module_menu.pack(side='left', expand=True, padx=20)
-        self.module_selection.trace('w', lambda a, b, c, module_window=self: selection_callback(module_window=module_window))
+        self.module_selection.trace_add('write', lambda a, b, c, module_window=self: selection_callback(module_window=module_window))
 
         self.close_icon = icons.get_icon('x-lightgray')
         self.x_button = tk.Label(self.menu_frame, text='⨯', fg=text_color(), bg=bg_color(), cursor='hand2')


### PR DESCRIPTION
Three provider-agnostic fixes found while getting loom running on a current Linux distro. No new dependencies, no behaviour changes beyond the bugs described.

## 1. `Variable.trace` was removed in Tk 9

Tcl/Tk 9 dropped the deprecated `trace variable` subcommand, which is what Python's `Variable.trace(mode, callback)` shells out to. On any Tk 9 build, every `var.trace('w', ...)` call raises:

```
_tkinter.TclError: bad option "variable": must be add, info, or remove
```

There are 10 of these across `components/dialogs.py`, `components/modules.py`, `components/templates.py` and `view/panes.py`, and they fire while building panes, so the app can't open a pane at all on a distro that has moved to Tk 9.

Replaced with the `trace_add('write', ...)` form. That has been available since Python 3.6 and passes the callback the same `(name, index, mode)` arguments, so no call sites needed changing.

## 2. Generation-thread callbacks never reached the main thread

Generation runs in a worker thread, and two of its callbacks end up touching Tk:

**`delete_failed_nodes`** called `self.tree_updated(...)` directly — exactly what the `# DO NOT CALL FROM THREAD: self.tree_updated()` comment two functions above it warns against. It runs the whole view refresh on the worker thread. Under Tk 9 that aborts the process outright:

```
Unknown display passed to Tk_CreateErrorHandler
```

So any failed generation killed the app rather than just dropping the failed nodes.

**`post_generation`** avoided that by going through `self.app.event_generate("<<NewNodes>>", when="tail")` instead. But Tk queues virtual events per-thread, so an event generated from a worker thread is never delivered to the main thread's event loop, and `edit_new_nodes` simply never ran. I checked this empirically rather than assuming: firing the event from a worker thread produces no dispatch, while the identical call on the main thread dispatches normally. It's a silent no-op rather than a crash, which is presumably why it went unnoticed.

Both now go through a small `queue.Queue` that the main thread drains from an `after()` timer (`call_on_main_thread` / `drain_main_thread_queue`), which is the conventional way to hand work from a worker thread into tkinter. Callbacks that raise are caught and traced so one bad callback doesn't stop the drain loop.

Verified by driving `default_generate` from worker threads against a real API and asserting both callbacks execute on `MainThread`.

## 3. `retry`'s `on_failure` result was discarded

In `util/util.py`, the retry decorator's failure branch called `on_failure(*args, **kwargs)` without returning it. Every exhausted retry chain therefore returned `None` instead of the handler's intended `("", None)`, and the caller's unpack blew up with:

```
TypeError: cannot unpack non-iterable NoneType object
```

which buries whatever error actually exhausted the retries. One-line fix: `return on_failure(...)`.

---

Tested on Python 3.11 with Tcl/Tk 9.0 on Arch/Manjaro.

---

I have some further work sitting in a branch that I've deliberately kept out of this PR, since it's more opinionated than a bug fix:

- **Dependency unpinning.** The current pins don't install on Python 3.11+ — `pandas==1.3.3` pulls a numpy that won't compile against modern toolchains, and `tk==0.1.0` in `requirements.txt` is an unrelated PyPI package rather than the tkinter bindings (those ship with CPython).
- **A `uv` / `pyproject.toml` setup**, as an alternative to the requirements.txt flow.
- **OpenRouter provider support**, including a completions-endpoint variant so a story prompt gets continued rather than replied to.

Would you welcome any of those as follow-up PRs, or would you rather keep the project as it stands? Completely fine either way — happy to just leave these three fixes here if the project is in maintenance mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
